### PR TITLE
fix: use requests.exceptions.JSONDecodeError for ensuring compatibility with different json implementations used by requests

### DIFF
--- a/conda/exceptions.py
+++ b/conda/exceptions.py
@@ -6,11 +6,13 @@ import json
 import os
 import sys
 from datetime import timedelta
-from json.decoder import JSONDecodeError
+from requests.exceptions import JSONDecodeError
+from simplejson.
 from logging import getLogger
 from os.path import join
 from textwrap import dedent
 from traceback import format_exception, format_exception_only
+from typing import Optional
 
 from conda.common.iterators import groupby_to_dict as groupby
 
@@ -494,7 +496,7 @@ class ChannelNotAllowed(ChannelError):
 class UnavailableInvalidChannel(ChannelError):
     status_code: str | int
 
-    def __init__(self, channel, status_code, response=None):
+    def __init__(self, channel, status_code, response: Optional[requests.models.Response]=None):
         # parse channel
         channel = Channel(channel)
         channel_name = channel.name


### PR DESCRIPTION
Otherwise, conda misses JSONDecodeErrors generated by simplejson if that is in the same env and thereby used by the requests package for decoding the json response. In turn, this can lead to aborting source download after trying the first given source in a meta.yaml instead of trying all of them.
Also see requests [JSONDecodeError implementation](https://github.com/psf/requests/blob/302225334678490ec66b3614a9dddb8a02c5f4fe/requests/exceptions.py#L31), which either inherits from simplejson's JSONDecodeError or from the Python std libs json.JSONDecodeError.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
